### PR TITLE
Add a .cirrus.yml file for automated builds.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,96 @@
+linux-x86_64-binaries_task:
+    container:
+        image: ubuntu:latest
+
+    setup_script:
+        - apt-get update && apt-get -y install build-essential libgtk2.0-dev libpulse-dev mesa-common-dev libgtksourceview2.0-dev libcairo2-dev libsdl2-dev libxv-dev libao-dev libopenal-dev libudev-dev
+
+    compile_script:
+        - make -C genius
+        - make -C icarus
+        - make -C higan target=higan
+
+    package_script:
+        - mkdir higan-nightly
+        - cp -a genius/out/genius higan-nightly/genius
+        - cp -a icarus/out/icarus higan-nightly/icarus
+        - cp -a icarus/Database higan-nightly/
+        - cp -a icarus/Firmware higan-nightly/
+        - cp -a higan/out/higan higan-nightly/higan
+        - cp -a higan/System/ higan-nightly/
+        - cp -a GPLv3.txt higan-nightly/
+
+    higan-nightly_artifacts:
+        path: "higan-nightly/**"
+
+freebsd-x86_64-binaries_task:
+    freebsd_instance:
+        image: freebsd-12-0-release-amd64
+
+    setup_script:
+        - pkg install --yes gmake gdb gcc8 pkgconf sdl2 openal-soft gtksourceview2 libXv
+
+    compile_script:
+        - gmake -C genius
+        - gmake -C icarus
+        - gmake -C higan target=higan
+
+    package_script:
+        - mkdir higan-nightly
+        - cp -a genius/out/genius higan-nightly/genius
+        - cp -a icarus/out/icarus higan-nightly/icarus
+        - cp -a icarus/Database higan-nightly/
+        - cp -a icarus/Firmware higan-nightly/
+        - cp -a higan/out/higan higan-nightly/higan
+        - cp -a higan/System/ higan-nightly/
+        - cp -a GPLv3.txt higan-nightly/
+
+    higan-nightly_artifacts:
+        path: "higan-nightly/**"
+
+windows-x86_64-binaries_task:
+    container:
+        image: ubuntu:latest
+
+    setup_script:
+        - apt-get update && apt-get -y install build-essential mingw-w64
+
+    compile_script:
+        # genius does not currently build on Windows due to lack of a combo edit control in hiro
+        #- make -C genius platform=windows compiler="x86_64-w64-mingw32-g++" windres="x86_64-w64-mingw32-windres"
+        - make -C icarus platform=windows compiler="x86_64-w64-mingw32-g++" windres="x86_64-w64-mingw32-windres"
+        - make -C higan target=higan platform=windows compiler="x86_64-w64-mingw32-g++" windres="x86_64-w64-mingw32-windres"
+
+    package_script:
+        - mkdir higan-nightly
+        #- cp -a genius/out/genius higan-nightly/genius.exe
+        - cp -a icarus/out/icarus higan-nightly/icarus.exe
+        - cp -a icarus/Database higan-nightly/
+        - cp -a icarus/Firmware higan-nightly/
+        - cp -a higan/out/higan higan-nightly/higan.exe
+        - cp -a higan/System/ higan-nightly/
+        - cp -a GPLv3.txt higan-nightly/
+
+    higan-nightly_artifacts:
+        path: "higan-nightly/**"
+
+macOS-x86_64-binaries_task:
+    osx_instance:
+        image: mojave-base
+
+    compile_script:
+        - make -C icarus
+        - make -C higan target=higan
+
+    package_script:
+        - mkdir higan-nightly
+        # FIXME: How does icarus on macOS find its Database and Firmware directories?
+        - cp -a icarus/out/icarus.app higan-nightly/
+        - cp -a icarus/Database higan-nightly/
+        - cp -a icarus/Firmware higan-nightly/
+        - cp -a higan/out/higan.app higan-nightly/
+        - cp -a higan/System/ higan-nightly/
+        - cp -a GPLv3.txt higan-nightly/
+
+    higan-nightly_artifacts:
+        path: "higan-nightly/**"


### PR DESCRIPTION
This file teaches Cirrus CI how to build higan for Linux, FreeBSD, Windows and macOS. The build results for this particular PR can be seen at https://cirrus-ci.com/build/5763597265797120

The build artefacts are available to download by clicking around the build results, but there's also stable "download latest artefact" URLs we can put into the README. I'll make another PR to add those once this one lands.

Currently the `package_script` for each task scoops up the binaries I know about into a `.zip` file, which *should* work, but there's probably more work to be done to make these useful, like #4. Even if we don't make full portable builds, we should probably write some installation instructions or something.