### PR TITLE
Set Icarus' output folder to Higan's default path

### DIFF
--- a/icarus/media/media.cpp
+++ b/icarus/media/media.cpp
@@ -1,6 +1,6 @@
 auto Media::construct() -> void {
   database = BML::unserialize(file::read(locate({"Database/", name(), ".bml"})));
-  pathname = {Path::user(), "Emulation/", name(), "/"};
+  pathname = {Path::user(), "higan/", name(), "/Cartridge/"};
 }
 
 auto Media::read(string location, string suffix) -> vector<uint8_t> {


### PR DESCRIPTION
This is related to the issue https://github.com/byuu/higan/issues/18 I opened a moment ago. I think it's a quick workaround and works for me at least. Sorry for the spam!