### PR TITLE
Z80::instructionIN_a_in shouldn't modify CPU flags

### DIFF
--- a/higan/component/processor/z80/instructions.cpp
+++ b/higan/component/processor/z80/instructions.cpp
@@ -247,10 +247,10 @@ auto Z80::instructionIM_o(uint2 code) -> void { Q = 0;
   IM = code;
 }
 
-auto Z80::instructionIN_a_in() -> void { Q = 1;
+auto Z80::instructionIN_a_in() -> void { Q = 0;
   WZL = operand();
   WZH = A;
-  A = IN(in(WZ++));
+  A = in(WZ++);
 }
 
 auto Z80::instructionIN_r_ic(uint8& x) -> void { Q = 1;


### PR DESCRIPTION
This fixes the broken title screen graphics in R-Type and Kujaku Ou. It does not however fix the broken save menu in Phantasy Star.