### PR TITLE
Don't include sys/mman.h when not using mprotect

### DIFF
--- a/libco/aarch64.c
+++ b/libco/aarch64.c
@@ -6,7 +6,9 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <unistd.h>
-#include <sys/mman.h>
+#ifdef LIBCO_MPROTECT
+  #include <sys/mman.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/libco/amd64.c
+++ b/libco/amd64.c
@@ -99,7 +99,9 @@ static void (*co_swap)(cothread_t, cothread_t) = 0;
   };
 
   #include <unistd.h>
-  #include <sys/mman.h>
+  #ifdef LIBCO_MPROTECT
+    #include <sys/mman.h>
+  #endif
 
   static void co_init() {
     #ifdef LIBCO_MPROTECT

--- a/libco/arm.c
+++ b/libco/arm.c
@@ -5,7 +5,9 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <sys/mman.h>
+#ifdef LIBCO_MPROTECT
+  #include <sys/mman.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/libco/x86.c
+++ b/libco/x86.c
@@ -53,7 +53,9 @@ static const unsigned char co_swap_function[4096] = {
   }
 #else
   #include <unistd.h>
-  #include <sys/mman.h>
+  #ifdef LIBCO_MPROTECT
+    #include <sys/mman.h>
+  #endif
 
   static void co_init() {
     #ifdef LIBCO_MPROTECT


### PR DESCRIPTION
Some platforms don't have <sys/mman.h> (like the Nintendo Switch.)