### PR TITLE
Swap buttons

### DIFF
--- a/higan/target-byuu/emulator/game-boy.cpp
+++ b/higan/target-byuu/emulator/game-boy.cpp
@@ -115,8 +115,8 @@ auto GameBoyColor::input(higan::Node::Input node) -> void {
   if(name == "Down"  ) mapping = virtualPad.down;
   if(name == "Left"  ) mapping = virtualPad.left;
   if(name == "Right" ) mapping = virtualPad.right;
-  if(name == "B"     ) mapping = virtualPad.b;
-  if(name == "A"     ) mapping = virtualPad.a;
+  if(name == "B"     ) mapping = virtualPad.a;
+  if(name == "A"     ) mapping = virtualPad.b;
   if(name == "Select") mapping = virtualPad.select;
   if(name == "Start" ) mapping = virtualPad.start;
 


### PR DESCRIPTION
Swap the GameBoy A and B buttons on byuu's virtual gamepad to be consistent with the fc and sfc button layout.
I do realize that you told everyone not to send bug reports about byuu, so feel free to ignore this for now.